### PR TITLE
Add RNG action helper and sample spots

### DIFF
--- a/sample_spots.py
+++ b/sample_spots.py
@@ -1,0 +1,32 @@
+from poker_spot import PokerSpot
+
+# Example BTN vs BB situations with approximate GTO frequencies and EVs
+
+spot1 = PokerSpot(
+    positions="BTN vs BB",
+    stack_sizes={"BTN": 50, "BB": 50},
+    board_cards=["Ah", "7c", "2h"],
+    hole_cards={"BTN": ["Ad", "Kd"], "BB": ["9h", "8h"]},
+    gto_strategy={"fold": 0.05, "call": 0.60, "raise": 0.35},
+    action_evs={"fold": -1.0, "call": 3.5, "raise": 4.0},
+)
+
+spot2 = PokerSpot(
+    positions="BTN vs BB",
+    stack_sizes={"BTN": 40, "BB": 40},
+    board_cards=["Kc", "Qd", "6s"],
+    hole_cards={"BTN": ["9h", "9d"], "BB": ["Ad", "Qs"]},
+    gto_strategy={"fold": 0.20, "call": 0.50, "raise": 0.30},
+    action_evs={"fold": -2.0, "call": 1.5, "raise": 2.0},
+)
+
+spot3 = PokerSpot(
+    positions="BTN vs BB",
+    stack_sizes={"BTN": 60, "BB": 60},
+    board_cards=["Ts", "8s", "4d"],
+    hole_cards={"BTN": ["As", "Jh"], "BB": ["Td", "9d"]},
+    gto_strategy={"fold": 0.30, "call": 0.40, "raise": 0.30},
+    action_evs={"fold": -1.5, "call": 0.8, "raise": 1.2},
+)
+
+sample_spots = [spot1, spot2, spot3]

--- a/trainer.py
+++ b/trainer.py
@@ -1,6 +1,22 @@
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Tuple, Dict
 import random
+
+
+def get_rng_action(strategy_dict: Dict[str, float]) -> str:
+    """Return a random action weighted by the provided GTO frequencies."""
+    if not strategy_dict:
+        raise ValueError("Strategy dictionary cannot be empty")
+
+    rnd = random.random()
+    cumulative = 0.0
+    for action, freq in strategy_dict.items():
+        cumulative += freq
+        if rnd <= cumulative:
+            return action
+
+    # Fallback in case of rounding errors
+    return list(strategy_dict.keys())[-1]
 
 @dataclass
 class PokerSpot:
@@ -11,13 +27,17 @@ class PokerSpot:
     recommended_action: str
     ev_loss_if_wrong: float
 
-def evaluate_action(spot: PokerSpot, action: str) -> Tuple[bool, float]:
-    """Simple evaluation stub returning whether the action is correct and EV loss."""
-    correct = action.strip().lower() == spot.recommended_action.lower()
+def evaluate_action(spot: PokerSpot, action: str, correct_action: str = None) -> Tuple[bool, float]:
+    """Return whether ``action`` matches ``correct_action`` and its EV loss."""
+    if correct_action is None:
+        correct_action = spot.recommended_action
+
+    correct = action.strip().lower() == correct_action.lower()
     ev_loss = 0.0 if correct else spot.ev_loss_if_wrong
     return correct, ev_loss
 
-def run_trainer_session(spots: List[PokerSpot], learning_mode: bool = False) -> None:
+def run_trainer_session(spots: List[PokerSpot], learning_mode: bool = False,
+                        rng_training: bool = False) -> None:
     """Run an interactive trainer session over a list of PokerSpot objects.
 
     Args:
@@ -39,24 +59,36 @@ def run_trainer_session(spots: List[PokerSpot], learning_mode: bool = False) -> 
         print(f"Hero Position: {spot.hero_position}")
         print(f"Villain Position: {spot.villain_position}")
         print(f"Board: {spot.board}")
+
+        if rng_training and getattr(spot, "gto_strategy", None):
+            spot_correct_action = get_rng_action(spot.gto_strategy)
+        else:
+            spot_correct_action = spot.recommended_action
+
         action = input("Your action: ")
-        correct, ev_loss = evaluate_action(spot, action)
+        correct, ev_loss = evaluate_action(spot, action, spot_correct_action)
         stats['total'] += 1
         if correct:
             stats['correct'] += 1
             print("Correct action!")
         else:
             stats['ev_loss'] += ev_loss
-            print(f"Incorrect. Recommended action: {spot.recommended_action}")
+            print(f"Incorrect. Recommended action: {spot_correct_action}")
 
             # Build a string representation of the spot's GTO strategy if
             # available. Fall back to simply echoing the recommended action.
             strategy = getattr(spot, "gto_strategy", None)
+            evs = getattr(spot, "action_evs", None)
             if strategy:
-                strategy_lines = [f"{act}: {freq:.2f}" for act, freq in strategy.items()]
+                strategy_lines = []
+                for act, freq in strategy.items():
+                    line = f"{act}: {freq:.2f}"
+                    if evs and act in evs:
+                        line += f" (EV {evs[act]:.2f})"
+                    strategy_lines.append(line)
                 gto_msg = "GTO Strategy:\n" + "\n".join(strategy_lines)
             else:
-                gto_msg = f"Recommended action: {spot.recommended_action}"
+                gto_msg = f"Recommended action: {spot_correct_action}"
 
             if learning_mode:
                 print(gto_msg)


### PR DESCRIPTION
## Summary
- support optional action EVs in `PokerSpot`
- add `get_rng_action` for frequency-weighted random actions
- implement RNG training mode in `run_trainer_session`
- provide three example BTN vs BB spots with GTO frequencies and EVs

## Testing
- `python -m py_compile poker_spot.py trainer.py sample_spots.py`


------
https://chatgpt.com/codex/tasks/task_e_6841b8a4fe54832c85be64ea9116beb2