### PR TITLE
Add CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ run_trainer_session(sample_spots)
 PY
 ```
 
+Alternatively run the provided ``main.py`` script:
+
+```bash
+python3 main.py
+```
+
 During the session you'll be prompted for an action (`fold`, `call` or `raise`) for each spot. Statistics are printed after each hand and the program continues until you answer `n` when asked to continue.
 
 ### Trainer options

--- a/main.py
+++ b/main.py
@@ -1,0 +1,28 @@
+import argparse
+from sample_spots import sample_spots
+from trainer import run_trainer_session
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the poker training session")
+    parser.add_argument(
+        "--learning-mode",
+        action="store_true",
+        help="Automatically show the GTO strategy after an incorrect answer.",
+    )
+    parser.add_argument(
+        "--rng-training",
+        action="store_true",
+        help="Pick the correct action at random according to provided GTO frequencies.",
+    )
+    args = parser.parse_args()
+
+    run_trainer_session(
+        sample_spots,
+        learning_mode=args.learning_mode,
+        rng_training=args.rng_training,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `main.py` CLI to easily start a trainer session
- document running the trainer via the new script

## Testing
- `python3 -m py_compile *.py`
- `python3 main.py --help`

------
https://chatgpt.com/codex/tasks/task_e_6841bab7fef8832caae01ea0ea40024d