### PR TITLE
Fix trainer to use PokerSpot class

### DIFF
--- a/poker_spot.py
+++ b/poker_spot.py
@@ -21,6 +21,20 @@ class PokerSpot:
         self.gto_strategy = gto_strategy
         self.action_evs = action_evs or {}
 
+    def best_action(self):
+        """Return the recommended action based on EVs or GTO frequencies."""
+        if self.action_evs:
+            max_ev = max(self.action_evs.values())
+            for act, ev in self.action_evs.items():
+                if ev == max_ev:
+                    return act
+        if self.gto_strategy:
+            max_freq = max(self.gto_strategy.values())
+            for act, freq in self.gto_strategy.items():
+                if freq == max_freq:
+                    return act
+        return None
+
     def evaluate_action(self, player_action):
         """Evaluate whether the given action matches the GTO strategy.
 

--- a/trainer.py
+++ b/trainer.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass
-from typing import List, Tuple, Dict
+from typing import List, Dict
 import random
+from poker_spot import PokerSpot
 
 
 def get_rng_action(strategy_dict: Dict[str, float]) -> str:
@@ -18,23 +18,6 @@ def get_rng_action(strategy_dict: Dict[str, float]) -> str:
     # Fallback in case of rounding errors
     return list(strategy_dict.keys())[-1]
 
-@dataclass
-class PokerSpot:
-    """Represents a single training scenario."""
-    hero_position: str
-    villain_position: str
-    board: str
-    recommended_action: str
-    ev_loss_if_wrong: float
-
-def evaluate_action(spot: PokerSpot, action: str, correct_action: str = None) -> Tuple[bool, float]:
-    """Return whether ``action`` matches ``correct_action`` and its EV loss."""
-    if correct_action is None:
-        correct_action = spot.recommended_action
-
-    correct = action.strip().lower() == correct_action.lower()
-    ev_loss = 0.0 if correct else spot.ev_loss_if_wrong
-    return correct, ev_loss
 
 def run_trainer_session(spots: List[PokerSpot], learning_mode: bool = False,
                         rng_training: bool = False) -> None:
@@ -56,17 +39,19 @@ def run_trainer_session(spots: List[PokerSpot], learning_mode: bool = False,
     while True:
         spot = random.choice(spots)
         print("--- New Spot ---")
-        print(f"Hero Position: {spot.hero_position}")
-        print(f"Villain Position: {spot.villain_position}")
-        print(f"Board: {spot.board}")
+        print(f"Positions: {spot.positions}")
+        print(f"Stacks: {spot.stack_sizes}")
+        print(f"Board: {' '.join(spot.board_cards)}")
+        print(f"Hole Cards: {spot.hole_cards}")
 
         if rng_training and getattr(spot, "gto_strategy", None):
             spot_correct_action = get_rng_action(spot.gto_strategy)
         else:
-            spot_correct_action = spot.recommended_action
+            spot_correct_action = spot.best_action()
 
-        action = input("Your action: ")
-        correct, ev_loss = evaluate_action(spot, action, spot_correct_action)
+        action = input("Your action: ").strip().lower()
+        _, ev_loss, _ = spot.evaluate_action(action)
+        correct = action == spot_correct_action
         stats['total'] += 1
         if correct:
             stats['correct'] += 1


### PR DESCRIPTION
## Summary
- remove redundant dataclass implementation
- call `PokerSpot` from `poker_spot` and add `best_action`
- update trainer session logic accordingly

## Testing
- `python3 -m py_compile poker_spot.py trainer.py sample_spots.py main.py`
- `python3 - <<'PY'
from sample_spots import sample_spots
from trainer import run_trainer_session
inputs = iter(['raise','n'])
import builtins
builtins.input = lambda prompt='': next(inputs)
run_trainer_session(sample_spots)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6841bbc12bc0832cbd9f15e5662e5d78