### PR TITLE
Enable custom spot entry in Streamlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ streamlit run streamlit_app.py
 ```
 
 Use the sidebar to pick the training mode, review recent hand history and view your accuracy in real time.
+
+The sidebar also includes a **Custom Spot** section where you can enter your own
+board and hole cards along with action frequencies. Press *Use Custom Spot* to
+replace the current hand with your custom scenario.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -31,6 +31,11 @@ def format_hole_cards(hole_cards: Dict[str, List[str]]) -> str:
     return " | ".join(parts)
 
 
+def parse_cards(text: str) -> List[str]:
+    """Parse a space or comma separated card string into a list."""
+    return [c.strip() for c in text.replace(',', ' ').split() if c.strip()]
+
+
 
 def init_session():
     if 'spot' not in st.session_state:
@@ -85,6 +90,24 @@ for entry in reversed(st.session_state.history[-20:]):
     status = "✅" if entry['correct'] else "❌"
     board = format_cards(entry['board'])
     st.sidebar.write(f"{status} {board} - chose {entry['action']}")
+
+# Custom spot inputs
+with st.sidebar.expander("Custom Spot"):
+    pos_input = st.text_input("Positions", "BTN vs BB", key="custom_pos")
+    board_input = st.text_input("Board", "Ah Kd Ts", key="custom_board")
+    btn_input = st.text_input("BTN Cards", "Ad Kd", key="custom_btn")
+    bb_input = st.text_input("BB Cards", "Qs Js", key="custom_bb")
+    fold_freq = st.number_input("Fold freq", min_value=0.0, max_value=1.0, value=0.1, key="custom_fold")
+    call_freq = st.number_input("Call freq", min_value=0.0, max_value=1.0, value=0.5, key="custom_call")
+    raise_freq = st.number_input("Raise freq", min_value=0.0, max_value=1.0, value=0.4, key="custom_raise")
+    if st.button("Use Custom Spot"):
+        st.session_state.spot = PokerSpot(
+            positions=pos_input,
+            stack_sizes={"BTN": 50, "BB": 50},
+            board_cards=parse_cards(board_input),
+            hole_cards={"BTN": parse_cards(btn_input), "BB": parse_cards(bb_input)},
+            gto_strategy={"fold": fold_freq, "call": call_freq, "raise": raise_freq},
+        )
 
 spot: PokerSpot = st.session_state.spot
 


### PR DESCRIPTION
## Summary
- support creating a custom spot in the Streamlit app
- document the custom spot feature in the README

## Testing
- `python3 -m py_compile streamlit_app.py poker_spot.py trainer.py sample_spots.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6841c3907814832cb5d4dd7db1bc1016